### PR TITLE
Fix schema string type

### DIFF
--- a/default_schema.json
+++ b/default_schema.json
@@ -66,7 +66,7 @@
           "type": "object",
           "properties": {
             "taxType": {
-              "type": "String",
+              "type": "string",
               "description": "Tax Type (e.g., 'Austria 50')"
             },
             "taxableGainUSD": {


### PR DESCRIPTION
## Summary
- correct the casing for `taxType` in `default_schema.json`
- ensure JSON remains valid

## Testing
- `python -m json.tool default_schema.json`

------
https://chatgpt.com/codex/tasks/task_e_685ed12009ac832a88b5e3e4877eef42